### PR TITLE
Removed console.log from load-all AMD bootstrap

### DIFF
--- a/lib/buster-amd.js
+++ b/lib/buster-amd.js
@@ -11,7 +11,7 @@ function amdWrapper(paths, mapper) {
 
     return "define('buster', function(){ return buster; });"+
         "require([" + tests.join(", ") + "], function(" + identifiers.join(", ") +
-        ") {\n  console.log('loading');\n  buster.run();\n});";
+        ") {\n  buster.run();\n});";
 }
 
 module.exports =  {


### PR DESCRIPTION
The console.log statement was causing errors in IE `Uncaught Exception: 'console' is undefined`.

I couldn't see any real need to keep it in? If you think its important i could shim it?
