### PR TITLE
Add support for 'baseUrl' option

### DIFF
--- a/lib/buster-amd.js
+++ b/lib/buster-amd.js
@@ -16,7 +16,7 @@ function amdWrapper(paths, mapper, baseUrl) {
 
     // "normalize" to a baseUrl after buster requires the tests
     if (baseUrl) {
-        content += "require.config({ baseUrl: 'assetic/r' });";
+        content += "require.config({ baseUrl: '" + baseUrl + "' });";
     }
     return content;
 }

--- a/lib/buster-amd.js
+++ b/lib/buster-amd.js
@@ -2,16 +2,23 @@ function quote(t) {
     return "'" + t + "'";
 }
 
-function amdWrapper(paths, mapper) {
-    var tests = paths.map(mapper).map(quote);
-    var identifiers = paths.map(function (t, i) { return "t" + i; });
+function amdWrapper(paths, mapper, baseUrl) {
+    var tests = paths.map(mapper).map(quote),
+        identifiers = paths.map(function (t, i) { return "t" + i; }),
+        content = "";
 
     tests.unshift("'buster'");
     identifiers.unshift('buster');
 
-    return "define('buster', function(){ return buster; });"+
+    content = "define('buster', function(){ return buster; });" +
         "require([" + tests.join(", ") + "], function(" + identifiers.join(", ") +
         ") {\n  buster.run();\n});";
+
+    // "normalize" to a baseUrl after buster requires the tests
+    if (baseUrl) {
+        content += "require.config({ baseUrl: 'assetic/r' });";
+    }
+    return content;
 }
 
 module.exports =  {
@@ -20,6 +27,7 @@ module.exports =  {
     create: function (options) {
         var ext = Object.create(this);
         var mapper = options && options.pathMapper;
+        ext.baseUrl = options && options.baseUrl;
         ext.pathMapper = mapper || function (path) {
             return path.replace(/\.js$/, "").replace(/^\//, "");
         };
@@ -35,7 +43,7 @@ module.exports =  {
             var paths = rs.loadPath.paths();
             rs.addResource({
                 path: "/buster/load-all.js",
-                content: amdWrapper(rs.loadPath.paths(), this.pathMapper)
+                content: amdWrapper(rs.loadPath.paths(), this.pathMapper, this.baseUrl)
             });
             if (!this.preloadTests) {
                 rs.loadPath.clear();

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
         "buster-core": ">=0.6.0"
     },
     "devDependencies": {
-        "buster": "*"
+        "buster": "git://github.com/InterNations/buster.git#09deba47a819f3ad1f25909f34869e74c2b254f9"
     }
 }


### PR DESCRIPTION
Useful when the baseUrl of the AMD when running tests would be
different from the baseUrl when running dev/production code.
See [this example](https://github.com/jodal/buster-coffee/blob/master/demo-amd/test/require-config.js).
